### PR TITLE
test_binary_search_tree.py false negative

### DIFF
--- a/binary_search_tree/test_binary_search_tree.py
+++ b/binary_search_tree/test_binary_search_tree.py
@@ -10,8 +10,8 @@ class BinarySearchTreeTests(unittest.TestCase):
     self.bst.insert(3)
     self.bst.insert(7)
     self.bst.insert(6)
-    self.assertEqual(self.bst.left.right.value, 3)
-    self.assertEqual(self.bst.right.left.value, 6)
+    self.assertEqual(self.bst.left["right"]["value"], 3)
+    self.assertEqual(self.bst.right["left"]["value"], 6)
 
   def test_contains(self):
     self.bst.insert(2)


### PR DESCRIPTION
#### Expected behaviour: 
lets you pass if -> left -> right value  ==   3 && right left value == 6 

#### actual behaviour: 
It doesn't pass because the object is accessed in the wrong way

Fix:
Change the test to access the object via [" "] notation, it accesses the object correctly & gives no false negatives