### PR TITLE
remove unnecessary passed arguments to methods in test_print_traversal()

### DIFF
--- a/binary_search_tree/test_binary_search_tree.py
+++ b/binary_search_tree/test_binary_search_tree.py
@@ -77,30 +77,30 @@ class BinarySearchTreeTests(unittest.TestCase):
         self.bst.insert(4)
         self.bst.insert(2)
 
-        self.bst.in_order_print(self.bst)
+        self.bst.in_order_print()
 
         output = sys.stdout.getvalue()
         self.assertEqual(output, "1\n2\n3\n4\n5\n6\n7\n8\n")
 
         sys.stdout = io.StringIO()
-        self.bst.bft_print(self.bst)
+        self.bst.bft_print()
         output = sys.stdout.getvalue()
         self.assertTrue(output == "1\n8\n5\n3\n7\n2\n4\n6\n" or
                         output == "1\n8\n5\n7\n3\n6\n4\n2\n")
 
         sys.stdout = io.StringIO()
-        self.bst.dft_print(self.bst)
+        self.bst.dft_print()
         output = sys.stdout.getvalue()
         self.assertTrue(output == "1\n8\n5\n7\n6\n3\n4\n2\n" or
                         output == "1\n8\n5\n3\n2\n4\n7\n6\n")
 
         sys.stdout = io.StringIO()
-        self.bst.pre_order_dft(self.bst)
+        self.bst.pre_order_dft()
         output = sys.stdout.getvalue()
         self.assertEqual(output, "1\n8\n5\n3\n2\n4\n7\n6\n")
 
         sys.stdout = io.StringIO()
-        self.bst.post_order_dft(self.bst)
+        self.bst.post_order_dft()
         output = sys.stdout.getvalue()
         self.assertEqual(output, "2\n4\n3\n6\n7\n5\n8\n1\n")
 


### PR DESCRIPTION
I had an issue running my last test function (test_print_traversals) so after I took a look at the function definition, I noticed some bugs. In line 80, when calling the  bst.in_order_print() method, there was the BSTNode instance passed in as an argument, there's no need to pass it as argument since you're calling it with it, the instance gets passed automatically.
The same issue is at line 86, 92, 98, 103.